### PR TITLE
Add CLI utility for scanning NFS-related errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,3 +329,21 @@ The pipeline adds several labels:
 * The provisioned storage is not guaranteed. You may allocate more than the NFS share's total size. The share may also not have enough storage space left to actually accommodate the request.
 * The provisioned storage limit is not enforced. The application can expand to use all the available storage regardless of the provisioned size.
 * Storage resize/expansion operations are not presently supported in any form. You will end up in an error state: `Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.`
+
+## Diagnosing NFS errors
+
+When you need to triage issues on a cluster that is already running the provisioner, application or node logs are often the first place you look. The repository now ships with a small helper utility that scans log files for messages that mention NFS along with common error keywords. This can help you quickly locate timeouts, access problems, or other suspicious events before diving deeper into the logs.
+
+Build and run the scanner locally:
+
+```sh
+$ go build ./cmd/nfs-error-scan
+$ ./nfs-error-scan /var/log/syslog
+```
+
+You can pass one or more files or directories. When a directory is provided the tool walks it recursively and reports all matches, printing the file name, line number, and the log line that appears to contain an NFS-related error. If no files are listed, it reads from standard input so you can easily pipe log streams into it.
+
+```sh
+$ journalctl -u kubelet | ./nfs-error-scan
+```
+

--- a/cmd/nfs-error-scan/main.go
+++ b/cmd/nfs-error-scan/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type result struct {
+	file string
+	line int
+	text string
+}
+
+var errorTokens = []string{
+	"error",
+	"fail",
+	"denied",
+	"timeout",
+	"stale",
+	"not responding",
+	"unreachable",
+	"unable",
+	"refused",
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [file or directory]...\n", os.Args[0])
+		fmt.Fprintln(flag.CommandLine.Output(), "If no arguments are supplied, input is read from stdin.")
+	}
+
+	flag.Parse()
+
+	tokens := prepareTokens(errorTokens)
+
+	var matches []result
+	var err error
+
+	if flag.NArg() == 0 {
+		matches, err = scanReader("<stdin>", os.Stdin, tokens)
+	} else {
+		matches, err = scanPaths(flag.Args(), tokens)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "scan error: %v\n", err)
+		os.Exit(1)
+	}
+
+	report(matches)
+}
+
+func scanPaths(paths []string, tokens []string) ([]result, error) {
+	if len(paths) == 0 {
+		return nil, errors.New("no paths provided")
+	}
+
+	var matches []result
+
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return matches, fmt.Errorf("stat %s: %w", path, err)
+		}
+
+		if info.IsDir() {
+			err = filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				if d.IsDir() {
+					return nil
+				}
+
+				fileMatches, err := scanFile(p, tokens)
+				if err != nil {
+					return err
+				}
+
+				matches = append(matches, fileMatches...)
+				return nil
+			})
+			if err != nil {
+				return matches, fmt.Errorf("walk %s: %w", path, err)
+			}
+			continue
+		}
+
+		fileMatches, err := scanFile(path, tokens)
+		if err != nil {
+			return matches, err
+		}
+
+		matches = append(matches, fileMatches...)
+	}
+
+	return matches, nil
+}
+
+func scanFile(path string, tokens []string) ([]result, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer file.Close()
+
+	return scanReader(path, file, tokens)
+}
+
+func scanReader(name string, reader io.Reader, tokens []string) ([]result, error) {
+	scanner := bufio.NewScanner(reader)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	var matches []result
+	lineNumber := 0
+
+	for scanner.Scan() {
+		lineNumber++
+		text := scanner.Text()
+		if hasNFSError(text, tokens) {
+			matches = append(matches, result{file: name, line: lineNumber, text: text})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return matches, fmt.Errorf("scan %s: %w", name, err)
+	}
+
+	return matches, nil
+}
+
+func hasNFSError(line string, tokens []string) bool {
+	normalized := strings.ToLower(line)
+	if !strings.Contains(normalized, "nfs") {
+		return false
+	}
+
+	for _, token := range tokens {
+		if strings.Contains(normalized, token) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func prepareTokens(tokens []string) []string {
+	prepared := make([]string, len(tokens))
+	for i, token := range tokens {
+		prepared[i] = strings.ToLower(token)
+	}
+
+	return prepared
+}
+
+func report(matches []result) {
+	if len(matches) == 0 {
+		fmt.Println("No potential NFS errors found.")
+		return
+	}
+
+	fmt.Println("Potential NFS errors:")
+	for _, m := range matches {
+		fmt.Printf("%s:%d: %s\n", m.file, m.line, m.text)
+	}
+	fmt.Printf("\nTotal matches: %d\n", len(matches))
+}

--- a/cmd/nfs-error-scan/main_test.go
+++ b/cmd/nfs-error-scan/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHasNFSError(t *testing.T) {
+	tokens := prepareTokens(errorTokens)
+
+	cases := []struct {
+		name     string
+		line     string
+		expected bool
+	}{
+		{name: "nfs error", line: "May 12 08:01:02 node kernel: NFS error: server not responding", expected: true},
+		{name: "nfs fail", line: "nfs mount fail due to timeout", expected: true},
+		{name: "no nfs", line: "generic error occurred", expected: false},
+		{name: "nfs without error token", line: "nfs operation completed successfully", expected: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasNFSError(tc.line, tokens); got != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestScanReader(t *testing.T) {
+	input := "NFS error: access denied\nThis line is fine\nAnother nfs timeout detected\n"
+	reader := strings.NewReader(input)
+
+	tokens := prepareTokens(errorTokens)
+	matches, err := scanReader("test.log", reader, tokens)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+
+	if matches[0].line != 1 {
+		t.Fatalf("expected first match on line 1, got %d", matches[0].line)
+	}
+
+	if matches[1].line != 3 {
+		t.Fatalf("expected second match on line 3, got %d", matches[1].line)
+	}
+}


### PR DESCRIPTION
## Summary
- add a small CLI under cmd/nfs-error-scan that scans files or directories for log lines mentioning NFS together with common error phrases
- report the tool in the README so users can quickly find and use it when troubleshooting

## Testing
- go test ./cmd/nfs-error-scan

------
https://chatgpt.com/codex/tasks/task_e_68e637bdedc88324828dacd3a8082af0