### PR TITLE
Add Go tests to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      -
+        name: Run Go tests
+        run: go test ./...
+      -
         name: Prepare
         id: prep
         run: |


### PR DESCRIPTION
## Summary
- install the Go toolchain in the release workflow using the version from go.mod
- run the Go test suite before building and pushing new release images

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e63a7c5f808324b538fe303d67d5bc