### PR TITLE
chore: update dependencies and build tooling

### DIFF
--- a/.github/workflows/helm-chart-lint.yml
+++ b/.github/workflows/helm-chart-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Set up Go
         uses: actions/setup-go@v4
@@ -51,14 +51,14 @@ jobs:
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to the container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -66,7 +66,7 @@ jobs:
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.multiarch

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM golang:1.19 as build-env
 
 # xx wraps go to automatically configure $GOOS, $GOARCH, and $GOARM
 # based on TARGETPLATFORM provided by Docker.
-COPY --from=tonistiigi/xx:golang-1.0.0 / /
+COPY --from=tonistiigi/xx:1.6.1 / /
 
 ARG APP_FOLDER
 

--- a/docs/dependency-upgrades-2024-07.md
+++ b/docs/dependency-upgrades-2024-07.md
@@ -1,0 +1,32 @@
+# Dependency and tooling refresh overview
+
+This note summarises the practical benefits of the dependency and automation
+updates introduced in the latest maintenance work.
+
+## Go module updates
+
+- **github.com/golang/glog v1.2.4** – keeps the provisioner on the
+  most recent upstream logging fixes so we inherit improvements around
+  flag handling and log flushing behaviour that have landed since the
+  previous tag.
+- **golang.org/x/net v0.23.0** – pulls in the current batch of security
+  and robustness patches for the Go networking stack, including fixes for
+  HTTP/2 request handling and DNS resolver edge-cases that were not
+  available in the older release.
+
+## Build tooling
+
+- **tonistiigi/xx 1.6.1** – updates the cross-compilation environment used by
+  the multi-architecture Docker build so we can target the latest
+  toolchains and receive upstream QEMU fixes.
+
+## CI / CD automation
+
+- **actions/checkout v4** – moves the GitHub workflows onto the Node 20 based
+  runner, ensuring long-term support from GitHub Actions.
+- **docker actions** – the login, setup-buildx, and build-push actions are kept
+  on their current major releases, which include compatibility fixes for
+  the latest Docker Engine versions.
+
+These upgrades are routine, but together they keep the project aligned with
+actively maintained tooling and hardened upstream libraries.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubernetes-sigs/nfs-subdir-external-provisioner
 go 1.19
 
 require (
-	github.com/golang/glog v1.0.0
+	github.com/golang/glog v1.2.4
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4
 	k8s.io/client-go v0.23.4
@@ -35,7 +35,7 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
@@ -58,7 +58,7 @@ require (
 replace (
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.11.1
 	golang.org/x/crypto => golang.org/x/crypto v0.17.0
-	golang.org/x/net => golang.org/x/net v0.17.0
+	golang.org/x/net => golang.org/x/net v0.23.0
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20220521103104-8f96da9f5d5e
 	k8s.io/api => k8s.io/api v0.23.4
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.4


### PR DESCRIPTION
## Summary
- bump github.com/golang/glog to v1.2.4 and golang.org/x/net to v0.23.0
- update the multi-arch Docker build stage to tonistiigi/xx 1.6.1
- refresh GitHub workflows to use actions/checkout v4 and the latest Docker actions

## Testing
- not run (network access to Go module proxy is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6731928708324b138d686383f8433